### PR TITLE
Export HBM as SRE.

### DIFF
--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -854,6 +854,8 @@ static DEVICE_ATTR(always_on, S_IRUGO | S_IWUSR | S_IWGRP,
 static DEVICE_ATTR(lcdoff, S_IRUGO, mdss_mdp_lcdoff_event, NULL);
 static DEVICE_ATTR(lpm, S_IRUGO|S_IWUSR, NULL, mdss_set_low_power_mode);
 static DEVICE_ATTR(hbm, S_IRUGO|S_IWUSR, NULL, mdss_set_hbm);
+// Also export hbm as sre, as this is what user space expects
+static DEVICE_ATTR(sre, S_IRUGO|S_IWUSR, NULL, mdss_set_hbm);
 #endif /*VENDOR_EDIT*/
 #ifdef VENDOR_EDIT
 /* YongPeng.Yi@SWDP.MultiMedia, 2015/05/19  Add for set cabc START */
@@ -879,6 +881,7 @@ static struct attribute *mdss_fb_attrs[] = {
 	&dev_attr_lcdoff.attr,
 	&dev_attr_lpm.attr,
 	&dev_attr_hbm.attr,
+	&dev_attr_sre.attr,
 	&dev_attr_closebl.attr,
 	&dev_attr_cabc.attr,
 #endif /*VENDOR_EDIT*/


### PR DESCRIPTION
The user space (namely hardware/cyanogen/cmhw) expects us to do so.

Change-Id: I43a4ce95e0c1390dc3ecd5058abb9d80a25f7384